### PR TITLE
changing middleware so it doesn't conflict with django admin

### DIFF
--- a/collab/middleware.py
+++ b/collab/middleware.py
@@ -8,6 +8,7 @@ class CheckForProfile(object):
     def process_request(self, request):
         if not(request.path == reverse('core:register') or
                request.path == reverse('login') or
+               'admin' in request.path or
                'widget' in request.path):
             if request.user.is_authenticated():
                 if not user_has_profile(request.user) or not request.user.is_active:


### PR DESCRIPTION
Django admin can't be accessed if you have an unregistered user. This is a problem when initially standing up collab - you can't register because there are no offices/teams unless you load a fixture.

The downside to this fix is that if you follow the Django best practice of obfuscating the Django admin URL, this won't work. In the future it should probably pull the admin URL then make sure the middleware doesn't redirect to the registration page.
