### PR TITLE
Prevent error if content_type or tag_category are 'None'

### DIFF
--- a/core/taggit/utils.py
+++ b/core/taggit/utils.py
@@ -32,7 +32,8 @@ def add_tags(obj, tag_str, tag_category_slug, creator, content_type_name):
     ti = TaggedItem()
     ti.tag = t
     ti.object_id = obj.id
-    ti.tag_category = TagCategory.objects.filter(slug=tag_category_slug)[0]
+    ti.tag_category = None if tag_category_slug is None else \
+                      TagCategory.objects.filter(slug=tag_category_slug)[0]
     ti.tag_creator = creator
     ti.content_type = ContentType.objects.filter(name=content_type_name)[0]
     ti.save()


### PR DESCRIPTION
content_type and tag_category are Nullable fields in the model, and executing Tag.add(tagname) will create a tag where those fields are null.  The add_tags() function, however, will crash if the value supplied for those fields are None.  This update will correct that issue so that add_tags() will handle 'None' parameters.
