### PR TITLE
Cherry pick fixture tweak so staff_directory tests pass

### DIFF
--- a/core/fixtures/core-test-fixtures.json
+++ b/core/fixtures/core-test-fixtures.json
@@ -148,7 +148,7 @@
                 "test1@example.com"
             ],
             "home_phone": "",
-            "org_group": null,
+            "org_group": 69,
             "things_im_good_at": "",
             "email_notifications": false,
             "updated_at": "2012-03-01T11:34:54Z"


### PR DESCRIPTION
Cherry picked from [this change](https://github.com/m3brown/collab/commit/1c4e4cd4285b0317d17796c8bc39e13ebfeb5d74#diff-4a398a0cee70f30d14d0440693733f6fR151) to allow staff directory tests to pass
