### PR TITLE
Allow apostrophe in usernames

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -121,12 +121,12 @@ class CollabUserCreationForm(UserCreationForm):
     """
     Modify the Django UserCreationForm with upated char limits for username
     """
-    username = forms.RegexField(max_length=75, regex=r'^[\w.@+-]+$',
+    username = forms.RegexField(max_length=75, regex=r"^[\w.'@+-]+$",
         help_text="Required. 75 characters or fewer. Letters, digits and " +
-                  "@/./+/-/_ only.",
+                  "@/./'/+/-/_ only.",
         error_messages={
             'invalid': "This value may contain only letters, numbers and " +
-                       "@/./+/-/_ characters."})
+                       "@/./'/+/-/_ characters."})
 
     class Meta:
         model = CollabUser
@@ -148,12 +148,12 @@ class CollabUserChangeForm(UserChangeForm):
     Modify the Django UserChangeForm with upated char limits for username
     """
     username = forms.RegexField(
-        max_length=75, regex=r"^[\w.@+-]+$",
+        max_length=75, regex=r"^[\w.@'+-]+$",
         help_text="Required. 75 characters or fewer. Letters, digits and " +
-                  "@/./+/-/_ only.",
+                  "@/./'/+/-/_ only.",
         error_messages={
             'invalid': "This value may contain only letters, numbers and " +
-                       "@/./+/-/_ characters."})
+                       "@/./'/+/-/_ characters."})
 
     class Meta:
         model = CollabUser

--- a/core/models.py
+++ b/core/models.py
@@ -47,9 +47,9 @@ class CollabUser(AbstractBaseUser, PermissionsMixin):
     ''' Override base User class to increases username limit to 75 '''
     username = models.CharField(max_length=75, unique=True,
         help_text='Required. 75 characters or fewer. Letters, numbers and ' +
-                  '@/./+/-/_ characters',
+                  "@/./'/+/-/_ characters",
         validators=[
-            validators.RegexValidator(re.compile('^[\w.@+-]+$'),
+            validators.RegexValidator(re.compile("^[\w.'@+-]+$"),
                                       'Enter a valid username.', 'invalid')
         ])
     first_name = models.CharField(max_length=75, blank=True)


### PR DESCRIPTION
Allows the django admin page to edit users with usernames like `O'Connor`