### PR TITLE
Requirements updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.5.4
-South
+South==0.7.6
 pytz
 django-dynamicresponse
 wsgiref
@@ -22,7 +22,7 @@ django-crispy-forms==1.3.1
 django-localflavor-us
 pycrypto
 django-fields==0.2.1
-markdown
+markdown==2.3.1
 django-markup
 django-widgeter
 feedparser


### PR DESCRIPTION
The latest versions of markdown and ply cause issues in collab.  Set the versions in the requirements.txt to prevent issues.

Also, set the version of South preemptively.  Todo: define all versions to prevent surprises in the future.