### PR TITLE
create user command fix for user model error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.sqlite
 *.sublime*
 *\.*swp
-.idea
 
 .coverage
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.sqlite
 *.sublime*
 *\.*swp
+.idea
 
 .coverage
 .DS_Store

--- a/core/management/commands/create_users.py
+++ b/core/management/commands/create_users.py
@@ -40,7 +40,8 @@ class Command(BaseCommand):
                 'username': email
             }
 
-            user = get_user_model(**user_attr)
+            userModel = get_user_model()
+            user = userModel(**user_attr)
             user.save()
 
             person_attr = {


### PR DESCRIPTION
The method 'get_user_model()' does not take any params. So the model had to be first retrieved then used to fix this.