### PR TITLE
Update haystack to support elasticsearch with SSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,8 @@ django-pipeline==1.3.11
 slimit==0.8.1
 ply==3.4
 django-cache-tools
-django-haystack==2.1.0
-pyelasticsearch==0.4.1
+django-haystack==2.3.2
+elasticsearch==2.1.0
 django-reversion==1.7
 django-crispy-forms==1.3.1
 django-localflavor-us


### PR DESCRIPTION
For SSL support in Elasticsearch, the following config settings should be used:

```python
HAYSTACK_CONNECTIONS['KWARGS'] = {
    'port': 443,
    'use_ssl': True,
    'verify_certs': True, #Optional
    'ca_certs': '<cert-path>', #Optional
}
```

These options don't work correctly with older versions of Haystack that use `pyelasticsearch` as the backend library.  Upgrading Haystack to a newer version enables the `elasticsearch` library, which supports these options.

The newest version of Haystack is 2.4.0, but this version drops support for Python 2.6/Django 1.5.  Therefore we'll have to stick with Haystack 2.3.2 for now.