### PR TITLE
create_user command uses same avatar as fixtures

### DIFF
--- a/core/management/commands/create_users.py
+++ b/core/management/commands/create_users.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
             person_attr = {
                 'office_location': office_location,
                 'allow_tagging': True,
-                'photo_file': 'avatars/default1.jpg',
+                'photo_file': 'avatars/default.jpg',
                 'stub': username.replace('.', ''),
                 'office_phone': '5555555555',
                 'user': user,


### PR DESCRIPTION
The collab fixtures use `default.jpg` for the sample avatar, but the create_user management command uses `default1.jpg`.  Let's make both of these use the same sample avatar.