### PR TITLE
Tag Django 1.5 compatible version of mptt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,5 @@ markdown==2.3.1
 django-markup
 django-widgeter
 feedparser
-django-mptt
+django-mptt==0.7.4
 requests==2.0.1


### PR DESCRIPTION
The latest release of django-mptt drops support for Django <= 1.7

https://github.com/django-mptt/django-mptt/releases/tag/0.8.0

Tag collab at version 0.7.4.