### PR TITLE
Update requests to the latest release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ django-markup
 django-widgeter
 feedparser
 django-mptt==0.7.4
-requests==2.0.1
+requests==2.9.0


### PR DESCRIPTION
The previous version of requests was chosen because it was the version current in our environment.  However, version 2.0.1 is not compatible with pyopenssl.  I get the following when running a `migrate` with a pyopenssl db connection:

```
File "/www/collab/venv/lib/python2.6/site-packages/requests/__init__.py", line 53, in <module>
    from .packages.urllib3.contrib import pyopenssl
File "/www/collab/venv/lib/python2.6/site-packages/requests/packages/urllib3/contrib/pyopenssl.py", line 55, in <module>
    orig_connectionpool_ssl_wrap_socket = connectionpool.ssl_wrap_socket
AttributeError: 'module' object has no attribute 'ssl_wrap_socket'
```

Updating to the latest version of requests, 2.9.0, resolves this error.