### PR TITLE
Fix bad elasticsearch search results

### DIFF
--- a/collab/settings.py
+++ b/collab/settings.py
@@ -92,6 +92,7 @@ INSTALLED_APPS = (
     'cache_tools',
     'crispy_forms',
     'haystack',
+    'elasticstack',
     'mptt',
     'pipeline',
     'reversion',
@@ -218,3 +219,7 @@ from settings_helper import load_app_middlewares
 MIDDLEWARE_CLASSES = load_app_middlewares(MIDDLEWARE_CLASSES)
 
 COMMENTS_APP = 'core.custom_comments'
+
+# If using elasticsearch, override search_analyzer for ngram/edgengram fields.
+# Otherwise, searching for "sample" will return any results that start with "sam"
+ELASTICSEARCH_DEFAULT_NGRAM_SEARCH_ANALYZER = 'standard'

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,7 @@ slimit==0.8.1
 ply==3.4
 django-cache-tools==0.1.1
 django-haystack==2.3.2
-# https://github.com/bennylope/elasticstack/pull/15
-git+git://github.com/m3brown/elasticstack#egg=elasticstack
+elasticstack==0.3.0
 elasticsearch==2.1.0
 django-reversion==1.7
 django-crispy-forms==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ slimit==0.8.1
 ply==3.4
 django-cache-tools==0.1.1
 django-haystack==2.3.2
+# https://github.com/bennylope/elasticstack/pull/15
+git+git://github.com/m3brown/elasticstack#egg=elasticstack
 elasticsearch==2.1.0
 django-reversion==1.7
 django-crispy-forms==1.3.1


### PR DESCRIPTION
This is a workaround for the issue detailed in [Haystack PR 1057](https://github.com/django-haystack/django-haystack/issues/1057).

Basically, built in Haystack doesn't work quite right when searching ngram and edgengram fields.  For example, with an edgengram field, if you search for "sample" you get any result that starts with "sam", like "samson" or "samford".  The fix is to define a 'search_analyzer' for the field.

I'm utilizing [elasticstack](https://github.com/bennylope/elasticstack), which recently added functionality from a really smart guy (PR [here](https://github.com/bennylope/elasticstack/pull/15)) to support a custom search_analyzer.

Background info on search_analyzer: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-analyzer.html

More background on the specific issue we're having:
http://stackoverflow.com/questions/15923480/elastic-search-search-analyzer-vs-index-analyzer