### PR TITLE
Add pillow to requirements.txt

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,4 +8,3 @@ factory-boy==1.2.0
 django-factory-boy==1.0.0
 BeautifulSoup4==4.4.1
 django-dynamic-fixture==1.8.5
-pillow==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ django-widgeter==0.1
 feedparser==5.1.3
 django-mptt==0.7.4
 requests==2.9.0
+pillow==3.0.0


### PR DESCRIPTION
At long last, resolving #21 by placing pillow in the requirements.txt.

This was avoided for *way too long* because we were stuck with PIL in a production environment for technical reasons.