### PR TITLE
Add missing items to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,8 @@ feedparser==5.1.3
 django-mptt==0.7.4
 requests==2.9.0
 pillow==3.0.0
+paramiko==1.16.0
+urllib3==1.14
+ecdsa==0.13
+futures==3.0.3
+odict==1.5.1


### PR DESCRIPTION
The current requirements did not include tagged versions of a couple 2nd level dependencies.  This resulted in some problems when installing from scratch. For example, newer versions of urllib3 don't work quite right, so we're tagging the older version of urllib3 that know works correctly.

Adding these requirements should allow collab to deploy in a new environment without any issues.