### PR TITLE
Cleanup Search Results Script

### DIFF
--- a/core/search/templates/search/search_results.js
+++ b/core/search/templates/search/search_results.js
@@ -1,54 +1,52 @@
+function collapseResults( group ) {
+    var results = $( group ).find( 'ol' ).children( 'li' );
+    if ( results.length > 5 ) {
+        results.hide().slice( 0, 5 ).show();
+        var link = $( '<a class="more_results btn" href="#">' + ( results.length - 5 ) + ' More results</a>' );
+        link.click( function( e ) {
+            e.preventDefault();
+            results.slideDown();
+            $( this ).hide();
+        } );
+        $( group ).append( link );
+    }
+}
+
 {% if wiki_installed %}
     {% autoescape off %}
-        $.getJSON('{{ wiki_search_json_url }}', function(data) {
-            results = data.query.search;
+        $.getJSON( '{{ wiki_search_json_url }}', function( data ) {
+            var results = data.query.search;
+            var dataModel = 'Wiki';
+            var wikiGroup = $( '.results-group[data-model="Wiki"]' );
+            var wikiCount = wikiGroup.find( '#wiki_count_hook' );
+            var wikiList = wikiGroup.find( '#wiki_results_hook' );
 
-            if (results.length > 0) {
-                $("#wiki_count_hook").html(results.length);
+            if ( results.length > 0 ) {
+                wikiCount.html( results.length );
 
-                var count = 0;
-
-                for (count = 0; count < results.length; count++) {
-                    var link = results[count].title.replace(' ', '_');
+                for ( var count = 0; count < results.length; count++ ) {
+                    var link = results[count].title.replace( ' ', '_' );
                     var html = '<li><a href="/wiki/index.php/' + link + '">';
                     html += results[count].title;
                     html += '</a> <br/>';
                     html += results[count].snippet
-                            .replace(/<(\/)?div.*?>/gm, '')
-                            .replace(/<(\/)?span.*?>/gm, "<$1b>");
+                            .replace( /<(\/)?div.*?>/gm, '' )
+                            .replace( /<(\/)?span.*?>/gm, "<$1b>" );
                     html += '</li>';
-                    $("#wiki_results_hook").append(html);
+                    wikiList.append( html );
                 }
-                collapse_results()
+                collapseResults( wikiGroup );
             } else {
-                $('.results-group[data-model="Wiki"]').hide();
-                $('#filterWiki').parent('li').hide();
+                wikiGroup.hide();
             };
-        });
+        } );
     {% endautoescape %}
 {% endif %}
+ 
+$( '.results-group' ).each( function( i ) {
+   var dataModel = $( this ).attr( 'data-model' );
 
-function collapse_results() {
-    $('.results-group').each(function(i) {
-        var results = $(this).find("ol").children("li");
-        if (results.length > 5) {
-            results.hide().slice(0, 5).show();
-            var link = $("<a class=\"more_results btn\" href=\"#\">" + (results.length - 5) + " More results</a>");
-            link.click(function(e) {
-                e.preventDefault();
-                results.slideDown();
-                $(this).hide();
-            });
-            $(this).children(".more_results").remove();
-            $(this).append(link);
-        }
-        
-    });
-}
-
-
-$('.search-checkbox').change(function() {
-    $('.results-group[data-model="' + $(this).val() + '"]').slideToggle();
-})
-
-collapse_results()
+   if ( dataModel !== 'Wiki' ) {
+       collapseResults( this );
+   }
+} );


### PR DESCRIPTION
A bit of cleanup before implementing the open state change request.

- Removed double firing of collapseResults
- Removed unused slideToggle
- Removed unused link deletion
- Removed usused `filterWiki` hide
- Updated naming to match standards
- Updated spacing/quotes to match standards