### PR TITLE
Stop appending empty wiki result to search results data

### DIFF
--- a/core/search/views.py
+++ b/core/search/views.py
@@ -74,9 +74,6 @@ def search_results_json(req, term='', context_models=''):
                                                 r.url,
                                                 results_count))
 
-    all_results.append({'category': 'Wiki', 'term': term,
-                        'search_slug': 'wiki'})
-
     return json_response(all_results)
 
 


### PR DESCRIPTION
Unclear why we were ever doing this, but it has to be removed in order for us to put the Wiki results at the top of the search autosuggest pop-up.

Test along with GHE/collab/greybar#13