### PR TITLE
Standardize on spelling out "alternate" everywhere

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -40,19 +40,21 @@ class RegistrationForm(forms.Form):
         max_length=100, label="Last name",
         error_messages={'required': required_validator['last_name']})
     title = forms.CharField(max_length=100, error_messages={'required':
-                            required_validator['title']})
+                            required_validator['title']},
+                            label="Role")
     office_location = forms.ModelChoiceField(
         queryset=OfficeLocation.objects.all(), required=False,
         empty_label="- - - - - - Select  - - - - -")
-    team = forms.ModelChoiceField(queryset=OrgGroup.objects.all().order_by(
-        'title'), error_messages={'required': required_validator['team']})
+    org_group = forms.ModelChoiceField(queryset=OrgGroup.objects.all().order_by(
+        'title'), error_messages={'required': required_validator['team']},
+        label="Office")
     email = forms.CharField(max_length=100, error_messages={'required':
                             required_validator['email']})
     office_phone = forms.CharField(max_length=100, error_messages={'required':
                                    required_validator['office_phone']})
     mobile_phone = forms.CharField(max_length=100, required=False)
     home_phone = forms.CharField(max_length=100, required=False,
-                                 label="Alt phone")
+                                 label="Alternate phone")
     photo_file = forms.FileField(required=False)
 
     def clean_email(self):
@@ -83,7 +85,7 @@ class AccountForm(forms.Form):
     office_phone = forms.CharField(max_length=100, error_messages={'required':
                                    required_validator['office_phone']})
     home_phone = forms.CharField(max_length=100, required=False,
-                                 label="Alt phone")
+                                 label="Alternate phone")
     office_location = forms.ModelChoiceField(
         queryset=OfficeLocation.objects.all(), required=False,
         empty_label="- - - - - - Select  - - - - -", label="Building")

--- a/core/views.py
+++ b/core/views.py
@@ -96,7 +96,7 @@ def add_user(req):
     user.first_name = req.POST['first_name']
     user.last_name = req.POST['last_name']
     user.save()
-    org_group = OrgGroup(pk=req.POST['team'])
+    org_group = OrgGroup(pk=req.POST['org_group'])
     office_location = OfficeLocation(pk=req.POST['office_location'])
 
     attributes = {


### PR DESCRIPTION
Also:

- Relabel "Title" to "Role on the registration page
- Rename the `team` field on the registration page to match the actual model field name of `org_group`, and relabel it to "Office", to match what happens on the edit profile page.

/cc @jimmynotjim @marcesher 