### PR TITLE
Fix Python 2.6 and 2.7 tests

### DIFF
--- a/core/search/views.py
+++ b/core/search/views.py
@@ -1,6 +1,10 @@
 import re
 import itertools
-from collections import OrderedDict
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 from django.shortcuts import render_to_response
 from django.http import HttpResponseRedirect
@@ -89,7 +93,7 @@ def search_results_json(req, term='', context_models=''):
                                                 r.model_name,
                                                 r.url,
                                                 results_count))
-    
+
     return json_response(all_results)
 
 

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -30,7 +30,7 @@ class ViewTest(Exam, WebTest):
         form['title'] = 'Djangonaut'
         form['email'] = 'user12@example.com'
         form['office_phone'] = '5553332222'
-        form.set('team', OrgGroup.objects.all()[0].pk)
+        form.set('org_group', OrgGroup.objects.all()[0].pk)
         form.set('office_location', 'DC123')
         return form
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ paramiko==1.16.0
 urllib3==1.14
 ecdsa==0.13
 futures==3.0.3
-odict==1.5.1
+ordereddict==1.1


### PR DESCRIPTION
This PR is intended to fix the Python 2.6 and 2.7 tests in Travis. There are two problems it fixes:

- The introduction of `OrderedDict` in f8651cc was not accompanied by a supporting `OrderedDict` implementation for Python 2.6. This is not a problem when running on RHEL, as described in #70, because RHEL adds `OrderedDict` to their Python 2.6 standard library. It looks like the "odict" package was intended to be included for this purpose. I've chosen to go with the "ordereddict" package instead, as it is a drop-in substitute and does not attempt any optimizations.
- The form-related tests were still using the "team" field, which was renamed to "org_group" in c7635d4.

This closes #70.